### PR TITLE
Remove unused webdriver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "class-extend": "^0.1.2",
     "lodash": "^3.10.1",
     "selenium-webdriver": "^2.47.0",
-    "util-arity": "^1.0.2",
-    "webdriver": "0.0.1"
+    "util-arity": "^1.0.2"
   },
   "devDependencies": {
     "cucumber": "^0.9.5",


### PR DESCRIPTION
This package is not used and causes NPM warnings: 

`npm WARN engine webdriver@0.0.1: wanted: {"node":"~0.6.6"} (current: {"node":"4.4.7","npm":"2.15.8"})`
